### PR TITLE
feature: pull images if really necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 d2p-migrator
 .*.swp
 bin/
+.idea/

--- a/ctrd/image/converter.go
+++ b/ctrd/image/converter.go
@@ -1,0 +1,330 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/remotes"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const manifestSizeLimit = 8e6 // 8MB
+
+type blobState struct {
+	diffID digest.Digest
+	empty  bool
+}
+
+// Converter converts schema1 manifests to schema2 on fetch
+type Converter struct {
+	contentStore content.Store
+	fetcher      remotes.Fetcher
+
+	pulledManifest *manifest
+
+	mu      sync.Mutex
+	blobMap map[digest.Digest]blobState
+
+	includeLayer bool
+}
+
+// NewConverter returns a new converter
+func NewConverter(contentStore content.Store, fetcher remotes.Fetcher) *Converter {
+	return &Converter{
+		contentStore: contentStore,
+		fetcher:      fetcher,
+		blobMap:      map[digest.Digest]blobState{},
+	}
+}
+
+// Handle fetching descriptors for a docker media type
+func (c *Converter) Handle(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema1Manifest:
+		if err := c.fetchManifest(ctx, desc); err != nil {
+			return nil, err
+		}
+
+		m := c.pulledManifest
+		if len(m.FSLayers) != len(m.History) {
+			return nil, errors.New("invalid schema 1 manifest, history and layer mismatch")
+		}
+
+		descs := make([]ocispec.Descriptor, 0, len(c.pulledManifest.FSLayers))
+
+		for i := range m.FSLayers {
+			if _, ok := c.blobMap[c.pulledManifest.FSLayers[i].BlobSum]; !ok {
+				empty, err := isEmptyLayer([]byte(m.History[i].V1Compatibility))
+				if err != nil {
+					return nil, err
+				}
+				c.blobMap[c.pulledManifest.FSLayers[i].BlobSum] = blobState{
+					empty: empty,
+				}
+			}
+		}
+		return descs, nil
+	case images.MediaTypeDockerSchema2LayerGzip:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("%v not support for schema 1 manifests", desc.MediaType)
+	}
+}
+
+// Convert a docker manifest to an OCI descriptor
+func (c *Converter) Convert(ctx context.Context) (ocispec.Descriptor, error) {
+	history, diffIDs, err := c.schema1ManifestHistory()
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "schema 1 conversion failed")
+	}
+
+	var img ocispec.Image
+	if err := json.Unmarshal([]byte(c.pulledManifest.History[0].V1Compatibility), &img); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to unmarshal image from schema 1 history")
+	}
+
+	img.History = history
+	img.RootFS = ocispec.RootFS{
+		Type:    "layers",
+		DiffIDs: diffIDs,
+	}
+
+	b, err := json.Marshal(img)
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to marshal image")
+	}
+
+	config := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageConfig,
+		Digest:    digest.Canonical.FromBytes(b),
+		Size:      int64(len(b)),
+	}
+
+	layers := make([]ocispec.Descriptor, len(diffIDs))
+	for i := range diffIDs {
+		layers[i] = ocispec.Descriptor{}
+	}
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		Config: config,
+		Layers: layers,
+	}
+
+	mb, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to marshal image")
+	}
+
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.Canonical.FromBytes(mb),
+		Size:      int64(len(mb)),
+	}
+
+	labels := map[string]string{}
+	labels["containerd.io/gc.ref.content.0"] = manifest.Config.Digest.String()
+	for i, ch := range manifest.Layers {
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = ch.Digest.String()
+	}
+
+	ref := remotes.MakeRefKey(ctx, desc)
+	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(mb), desc.Size, desc.Digest, content.WithLabels(labels)); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to write config")
+	}
+
+	ref = remotes.MakeRefKey(ctx, config)
+	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(b), config.Size, config.Digest); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to write config")
+	}
+
+	return desc, nil
+}
+
+func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor) error {
+	log.G(ctx).Debug("fetch schema 1")
+
+	rc, err := c.fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return err
+	}
+
+	b, err := ioutil.ReadAll(io.LimitReader(rc, manifestSizeLimit)) // limit to 8MB
+	rc.Close()
+	if err != nil {
+		return err
+	}
+
+	b, err = stripSignature(b)
+	if err != nil {
+		return err
+	}
+
+	var m manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	c.pulledManifest = &m
+
+	return nil
+}
+
+func (c *Converter) schema1ManifestHistory() ([]ocispec.History, []digest.Digest, error) {
+	if c.pulledManifest == nil {
+		return nil, nil, errors.New("missing schema 1 manifest for conversion")
+	}
+	m := *c.pulledManifest
+
+	if len(m.History) == 0 {
+		return nil, nil, errors.New("no history")
+	}
+
+	history := make([]ocispec.History, len(m.History))
+	diffIDs := []digest.Digest{}
+	for i := range m.History {
+		var h v1History
+		if err := json.Unmarshal([]byte(m.History[i].V1Compatibility), &h); err != nil {
+			return nil, nil, errors.Wrap(err, "failed to unmarshal history")
+		}
+
+		blobSum := m.FSLayers[i].BlobSum
+
+		state := c.blobMap[blobSum]
+
+		history[len(history)-i-1] = ocispec.History{
+			Author:     h.Author,
+			Comment:    h.Comment,
+			Created:    &h.Created,
+			CreatedBy:  strings.Join(h.ContainerConfig.Cmd, " "),
+			EmptyLayer: state.empty,
+		}
+
+		if !state.empty {
+			diffIDs = append([]digest.Digest{state.diffID}, diffIDs...)
+		}
+	}
+
+	return history, diffIDs, nil
+}
+
+type fsLayer struct {
+	BlobSum digest.Digest `json:"blobSum"`
+}
+
+type history struct {
+	V1Compatibility string `json:"v1Compatibility"`
+}
+
+type manifest struct {
+	FSLayers []fsLayer `json:"fsLayers"`
+	History  []history `json:"history"`
+}
+
+type v1History struct {
+	Author          string    `json:"author,omitempty"`
+	Created         time.Time `json:"created"`
+	Comment         string    `json:"comment,omitempty"`
+	ThrowAway       *bool     `json:"throwaway,omitempty"`
+	Size            *int      `json:"Size,omitempty"` // used before ThrowAway field
+	ContainerConfig struct {
+		Cmd []string `json:"Cmd,omitempty"`
+	} `json:"container_config,omitempty"`
+}
+
+// isEmptyLayer returns whether the v1 compatibility history describes an
+// empty layer. A return value of true indicates the layer is empty,
+// however false does not indicate non-empty.
+func isEmptyLayer(compatHistory []byte) (bool, error) {
+	var h v1History
+	if err := json.Unmarshal(compatHistory, &h); err != nil {
+		return false, err
+	}
+
+	if h.ThrowAway != nil {
+		return *h.ThrowAway, nil
+	}
+	if h.Size != nil {
+		return *h.Size == 0, nil
+	}
+
+	// If no `Size` or `throwaway` field is given, then
+	// it cannot be determined whether the layer is empty
+	// from the history, return false
+	return false, nil
+}
+
+type signature struct {
+	Signatures []jsParsedSignature `json:"signatures"`
+}
+
+type jsParsedSignature struct {
+	Protected string `json:"protected"`
+}
+
+type protectedBlock struct {
+	Length int    `json:"formatLength"`
+	Tail   string `json:"formatTail"`
+}
+
+// joseBase64UrlDecode decodes the given string using the standard base64 url
+// decoder but first adds the appropriate number of trailing '=' characters in
+// accordance with the jose specification.
+// http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31#section-2
+func joseBase64UrlDecode(s string) ([]byte, error) {
+	switch len(s) % 4 {
+	case 0:
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	default:
+		return nil, errors.New("illegal base64url string")
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+func stripSignature(b []byte) ([]byte, error) {
+	var sig signature
+	if err := json.Unmarshal(b, &sig); err != nil {
+		return nil, err
+	}
+	if len(sig.Signatures) == 0 {
+		return nil, errors.New("no signatures")
+	}
+	pb, err := joseBase64UrlDecode(sig.Signatures[0].Protected)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not decode %s", sig.Signatures[0].Protected)
+	}
+
+	var protected protectedBlock
+	if err := json.Unmarshal(pb, &protected); err != nil {
+		return nil, err
+	}
+
+	if protected.Length > len(b) {
+		return nil, errors.New("invalid protected length block")
+	}
+
+	tail, err := joseBase64UrlDecode(protected.Tail)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid tail base 64 value")
+	}
+
+	return append(b[:protected.Length], tail...), nil
+}

--- a/ctrd/image/image.go
+++ b/ctrd/image/image.go
@@ -1,0 +1,187 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func defaultRemoteContext() *containerd.RemoteContext {
+	return &containerd.RemoteContext{
+		Resolver: docker.NewResolver(docker.ResolverOptions{
+			Client: http.DefaultClient,
+		}),
+		Snapshotter: containerd.DefaultSnapshotter,
+	}
+}
+
+// PullManifest downloads the provided content into containerd's content store
+func PullManifest(ctx context.Context, c *containerd.Client, ref string, opts ...containerd.RemoteOpt) error {
+	pullCtx := defaultRemoteContext()
+	for _, o := range opts {
+		if err := o(c, pullCtx); err != nil {
+			return err
+		}
+	}
+	store := c.ContentStore()
+
+	ctx, done, err := c.WithLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done()
+
+	name, desc, err := pullCtx.Resolver.Resolve(ctx, ref)
+	if err != nil {
+		return err
+	}
+	fetcher, err := pullCtx.Resolver.Fetcher(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	var (
+		schema1Converter *Converter
+		handler          images.Handler
+	)
+	if desc.MediaType == images.MediaTypeDockerSchema1Manifest && pullCtx.ConvertSchema1 {
+		schema1Converter = NewConverter(store, fetcher)
+		handler = images.Handlers(append(pullCtx.BaseHandlers, schema1Converter)...)
+	} else {
+		handler = images.Handlers(append(pullCtx.BaseHandlers,
+			remotes.FetchHandler(store, fetcher),
+			childrenHandler(store, platforms.Default()))...,
+		)
+	}
+
+	if err := images.Dispatch(ctx, handler, desc); err != nil {
+		return err
+	}
+	if schema1Converter != nil {
+		desc, err = schema1Converter.Convert(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	imgrec := images.Image{
+		Name:   name,
+		Target: desc,
+		Labels: pullCtx.Labels,
+	}
+
+	is := c.ImageService()
+	if _, err := is.Create(ctx, imgrec); err != nil {
+		if !errdefs.IsAlreadyExists(err) {
+			return err
+		}
+
+		_, err := is.Update(ctx, imgrec)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// childrenHandler decodes well-known manifest types and returns their children.
+//
+// This is useful for supporting recursive fetch and other use cases where you
+// want to do a full walk of resources.
+//
+// One can also replace this with another implementation to allow descending of
+// arbitrary types.
+func childrenHandler(provider content.Provider, platform string) images.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		return children(ctx, provider, desc, platform)
+	}
+}
+
+// children returns the immediate children of content described by the descriptor.
+func children(ctx context.Context, provider content.Provider, desc ocispec.Descriptor, platform string) ([]ocispec.Descriptor, error) {
+	var descs []ocispec.Descriptor
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		p, err := content.ReadBlob(ctx, provider, desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+
+		var manifest ocispec.Manifest
+		if err := json.Unmarshal(p, &manifest); err != nil {
+			return nil, err
+		}
+
+		descs = append(descs, manifest.Config)
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		p, err := content.ReadBlob(ctx, provider, desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+
+		var index ocispec.Index
+		if err := json.Unmarshal(p, &index); err != nil {
+			return nil, err
+		}
+
+		if platform != "" {
+			matcher, err := platforms.Parse(platform)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, d := range index.Manifests {
+				if d.Platform == nil || matcher.Match(*d.Platform) {
+					descs = append(descs, d)
+				}
+			}
+		} else {
+			descs = append(descs, index.Manifests...)
+		}
+
+	case images.MediaTypeDockerSchema2Layer, images.MediaTypeDockerSchema2LayerGzip,
+		images.MediaTypeDockerSchema2LayerForeign, images.MediaTypeDockerSchema2LayerForeignGzip,
+		images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig,
+		ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip,
+		ocispec.MediaTypeImageLayerNonDistributable, ocispec.MediaTypeImageLayerNonDistributableGzip,
+		images.MediaTypeContainerd1Checkpoint, images.MediaTypeContainerd1CheckpointConfig:
+		// childless data types.
+		return nil, nil
+	default:
+		logrus.Warnf("encountered unknown type %v; children may not be fetched", desc.MediaType)
+	}
+
+	return descs, nil
+}
+
+// AddDefaultRegistryIfMissing will add default registry and namespace if missing.
+func AddDefaultRegistryIfMissing(ref string, defaultRegistry, defaultNamespace string) string {
+	var (
+		registry  string
+		remainder string
+	)
+
+	idx := strings.IndexRune(ref, '/')
+	if idx == -1 || !strings.ContainsAny(ref[:idx], ".:") {
+		registry, remainder = defaultRegistry, ref
+	} else {
+		registry, remainder = ref[:idx], ref[idx+1:]
+	}
+
+	if registry == defaultRegistry && !strings.ContainsAny(remainder, "/") {
+		remainder = defaultNamespace + "/" + remainder
+	}
+	return registry + "/" + remainder
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -73,5 +73,4 @@ func (d *Dockerd) ContainerStart(containerID string) error {
 	opts := types.ContainerStartOptions{}
 
 	return d.client.ContainerStart(context.Background(), containerID, opts)
-
 }

--- a/migrator/interface.go
+++ b/migrator/interface.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"context"
 
+	"github.com/pouchcontainer/d2p-migrator/ctrd"
 	"github.com/pouchcontainer/d2p-migrator/docker"
 )
 
@@ -11,16 +12,16 @@ var migratorFactory map[string]func(Config) (Migrator, error)
 // Migrator is an interface to migrate docker containers to other containers
 type Migrator interface {
 	// PreMigrate do something before migration
-	PreMigrate(ctx context.Context, cli *docker.Dockerd) error
+	PreMigrate(ctx context.Context, cli *docker.Dockerd, ctrdCli *ctrd.Client) error
 
 	// Migrate does migrate action
-	Migrate(ctx context.Context, cli *docker.Dockerd) error
+	Migrate(ctx context.Context, cli *docker.Dockerd, ctrdCli *ctrd.Client) error
 
 	// PostMigrate do something after migration
-	PostMigrate(ctx context.Context, cli *docker.Dockerd, dockerRpmName, pouchRpmPath string) error
+	PostMigrate(ctx context.Context, cli *docker.Dockerd, ctrdCli *ctrd.Client, dockerRpmName, pouchRpmPath string) error
 
 	// RevertMigration reverts migration
-	RevertMigration(ctx context.Context, cli *docker.Dockerd) error
+	RevertMigration(ctx context.Context, cli *docker.Dockerd, ctrdCli *ctrd.Client) error
 
 	// Cleanup does some clean works when migrator exited
 	Cleanup() error

--- a/migrator/live_migrate.go
+++ b/migrator/live_migrate.go
@@ -42,7 +42,7 @@ func NewLiveMigrator(cfg Config) (Migrator, error) {
 
 // PreMigrate prepares things for migration
 // TODO: need to add more details
-func (lm *liveMigrator) PreMigrate(ctx context.Context, dockerCli *docker.Dockerd) error {
+func (lm *liveMigrator) PreMigrate(ctx context.Context, dockerCli *docker.Dockerd, ctrdCli *ctrd.Client) error {
 	// Get all docker containers on host.
 	containers, err := dockerCli.ContainerList()
 	if err != nil {
@@ -70,12 +70,6 @@ func (lm *liveMigrator) PreMigrate(ctx context.Context, dockerCli *docker.Docker
 		pouchHomeDir  = getPouchHomeDir(lm.dockerHomeDir)
 		containersDir = path.Join(pouchHomeDir, "containers")
 	)
-
-	// get container client
-	ctrdCli, err := ctrd.NewCtrdClient()
-	if err != nil {
-		return fmt.Errorf("failed to get containerd client: %v", err)
-	}
 
 	for _, c := range containers {
 		lm.allContainers[c.ID] = false
@@ -139,13 +133,13 @@ func (lm *liveMigrator) doPrepare(ctx context.Context, ctrdCli *ctrd.Client, met
 }
 
 // Migrate just migrates network files here when living migration.
-func (lm *liveMigrator) Migrate(ctx context.Context, dockerCli *docker.Dockerd) error {
+func (lm *liveMigrator) Migrate(ctx context.Context, dockerCli *docker.Dockerd, ctrdCli *ctrd.Client) error {
 	pouchHomeDir := getPouchHomeDir(lm.dockerHomeDir)
 	return migrateNetworkFile(lm.dockerHomeDir, pouchHomeDir)
 }
 
 // PostMigrate does something after migration.
-func (lm *liveMigrator) PostMigrate(ctx context.Context, dockerCli *docker.Dockerd, dockerRpmName, pouchRpmPath string) error {
+func (lm *liveMigrator) PostMigrate(ctx context.Context, dockerCli *docker.Dockerd, ctrdCli *ctrd.Client, dockerRpmName, pouchRpmPath string) error {
 	// Get all docker containers on host again,
 	// In case, it may have containers being deleted
 	// Notes: we will lock host first, so there will have no
@@ -201,7 +195,7 @@ func (lm *liveMigrator) PostMigrate(ctx context.Context, dockerCli *docker.Docke
 }
 
 // RevertMigration reverts migration.
-func (lm *liveMigrator) RevertMigration(ctx context.Context, dockerCli *docker.Dockerd) error {
+func (lm *liveMigrator) RevertMigration(ctx context.Context, dockerCli *docker.Dockerd, ctrdCli *ctrd.Client) error {
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: zhuangqh zhuangqhc@gmail.com

It is unnecessary to re pull the existing docker image because user would build a brand new image when re-publishing their application. We just download the manifest of the image and store them under containerd. I've hack the containerd code to download manifest of an image only.

For those images which would be reused by new container created by pouch, we really re pull these images.

**known issue**
For schema v1 images, layers digest would be empty because the layer data should be fetched before calculating digest. 

fixes: #6 