### PR TITLE
refactor: rename containerd binary to 'd2p-containerd'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ advantanges of containerd 1.0.0+ to manage containers and images. Migration
 containers from docker's management to pouchd must take both image and
 container into consideration. Here are the steps to accomplish a migration job.
 
-### Step 1 - Install containerd 1.0.3 independently
+### Step 1 - Install containerd 1.0.3 independently, rename it to `d2p-containerd`
 
 ### Step 2 - Pull Images via ctr
 

--- a/ctrd/containerd.go
+++ b/ctrd/containerd.go
@@ -41,7 +41,9 @@ func StartContainerd(homeDir string, debug bool) (int, error) {
 		os.RemoveAll(socketAddr)
 	}
 
-	containerdPath, err := exec.LookPath("containerd")
+	// notes: we use a containerd binary named 'd2p-containerd'
+	// to avoid the name conflict with the original containerd.
+	containerdPath, err := exec.LookPath("d2p-containerd")
 	if err != nil {
 		return -1, fmt.Errorf("failed to find containerd binary %v", err)
 	}


### PR DESCRIPTION
rename the containerd binary to 'd2p-containerd' to avoid the name conflict.
This containerd is used during d2p migration only.

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>