### PR TITLE
feature: add plugin for d2p-migrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ d2p-migrator
 .*.swp
 bin/
 .idea/
+hook_plugins_build.go

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ linux:
 	@GOOS=linux go build -ldflags ${DEFAULT_LDFLAGS} -o bin/$(BINARY)
 
 .PHONY: build
-build: linux
+build: linux plugin
 
-
+.PHONY: plugin
+plugin: ## build hook plugin
+	@echo "build $@"
+	@./hack/module --add-plugin github.com/pouchcontainer/d2p-migrator/hookplugins/containerplugin

--- a/hack/module
+++ b/hack/module
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+function hook_plugins_module() {
+    # generate "hook_plugins_build.go" file
+    if [[ ! -f ${hook_plugins_build} ]]; then
+    cat << END > ${hook_plugins_build}
+// +build linux
+
+// The file is automatically generated, DON'T EDIT.
+
+package main
+
+END
+    fi
+
+    grep -q $1 ${hook_plugins_build}
+    if [[ $? -ne "0" ]]; then
+        echo "import _ \"$1\"" >> ${hook_plugins_build}
+    fi
+}
+
+function help_info() {
+echo "usage:"
+echo "     module [options]"
+echo ""
+echo "options:"
+echo "     --help, -h          Print help information"
+echo "     --add-plugin      Add a hook plugin to compile"
+echo "     --clean             Remove temporary codes, the 'build.go'"
+echo ""
+exit 0
+
+}
+
+GETOPTOUT=`getopt -o h --long help,clean,add-plugin: -- "$@"`
+
+clean=
+add_plugin=
+hook_plugins_build=hook_plugins_build.go
+
+# Note the quotes around `$GETOPTOUT': should delete the quotes
+ eval set -- $GETOPTOUT
+ while [ -n "$1" ]
+ do
+ case "$1" in
+     -h | --help )
+         help_info
+         exit 0
+         shift
+         ;;
+     --clean)
+         clean="true"
+         shift
+         ;;
+     --add-plugin)
+         add_plugin="$2"
+         shift 2
+         ;;
+     --)
+         shift
+         break
+         ;;
+      *)
+         echo "unknown parameters:"$1""
+         break
+         ;;
+ esac
+ done
+
+if  [[ "x$clean" == "xtrue" ]]; then
+    rm -f ${hook_plugins_build}
+fi
+
+if [[ "x$add_plugin" != "x" ]]; then
+    hook_plugins_module $add_plugin
+fi

--- a/hookplugins/ContainerPlugin.go
+++ b/hookplugins/ContainerPlugin.go
@@ -1,0 +1,27 @@
+package hookplugins
+
+import (
+	localtypes "github.com/pouchcontainer/d2p-migrator/pouch/types"
+)
+
+// ContainerPlugin will be called when converts docker container to pouch container.
+type ContainerPlugin interface {
+
+	// PostCovert will be called after convert container successful.
+	// this plugin pass two parameters:
+	// `dockerHomeDir`: specify docker home-dir that we can find the container meta informations.
+	// `cont`: which container we will deal with.
+	PostConvert(dockerHomeDir string, cont *localtypes.Container) error
+}
+
+var containerPlugin ContainerPlugin
+
+// RegisterContainerPlugin is used to register container plugin.
+func RegisterContainerPlugin(cp ContainerPlugin) {
+	containerPlugin = cp
+}
+
+// GetContainerPlugin returns the container plugin.
+func GetContainerPlugin() ContainerPlugin {
+	return containerPlugin
+}

--- a/hookplugins/containerplugin/covert_hook.go
+++ b/hookplugins/containerplugin/covert_hook.go
@@ -1,0 +1,18 @@
+package containerplugin
+
+import (
+	"github.com/pouchcontainer/d2p-migrator/hookplugins"
+	localtypes "github.com/pouchcontainer/d2p-migrator/pouch/types"
+)
+
+type contPlugin struct{}
+
+func init() {
+	hookplugins.RegisterContainerPlugin(&contPlugin{})
+}
+
+// PostCovert will be called after convert container successful
+func (c *contPlugin) PostConvert(dockerHomeDir string, cont *localtypes.Container) error {
+	// implement by developers
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: ziren.wzr <ziren.wzr@alibaba-inc.com>

Migrate pouch plugin policy to d2p-migrator, so that the developers can do specific things in the plugin when migrating docker containers to pouch containers.

Now I only add one plugin `ContainerPlugin` that has one point `PostConvert`, this will be called after convert a container's meta json.