### PR TITLE
fix time convert in docker to pouch

### DIFF
--- a/pouch/convertor/core.go
+++ b/pouch/convertor/core.go
@@ -3,6 +3,7 @@ package convertor
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	localtypes "github.com/pouchcontainer/d2p-migrator/pouch/types"
 	"github.com/pouchcontainer/d2p-migrator/utils"
@@ -33,7 +34,7 @@ func ToPouchContainerMeta(meta *dockertypes.ContainerJSON) (*localtypes.Containe
 		// Node
 		AppArmorProfile: meta.AppArmorProfile,
 		Args:            meta.Args,
-		Created:         meta.Created,
+		Created:         convertTime(meta.Created),
 		// TODO: default convert overlay2 container
 		Driver:         "overlay2",
 		HostnamePath:   meta.HostnamePath,
@@ -75,13 +76,13 @@ func ToPouchContainerMeta(meta *dockertypes.ContainerJSON) (*localtypes.Containe
 		Dead:       meta.State.Dead,
 		Error:      meta.State.Error,
 		ExitCode:   int64(meta.State.ExitCode),
-		FinishedAt: meta.State.FinishedAt,
+		FinishedAt: convertTime(meta.State.FinishedAt),
 		OOMKilled:  false,
 		Paused:     meta.State.Paused,
 		Pid:        int64(meta.State.Pid),
 		Restarting: false,
 		Running:    meta.State.Running,
-		StartedAt:  meta.State.StartedAt,
+		StartedAt:  convertTime(meta.State.StartedAt),
 		Status:     toContainerStatus(meta.State.Status),
 	}
 
@@ -589,4 +590,15 @@ func parseEnv(envs []string) (map[string]string, error) {
 	}
 
 	return result, nil
+}
+
+// convertTime convert time from Local to UTC. Because in docker time is parsed as Local, in pouch time
+// is parsed as UTC
+func convertTime(t string) string {
+	n, err := time.Parse(time.RFC3339Nano, t)
+	if err != nil {
+		return t
+	}
+
+	return n.UTC().Format(time.RFC3339Nano)
 }

--- a/pouch/convertor/core_test.go
+++ b/pouch/convertor/core_test.go
@@ -234,7 +234,7 @@ func TestToPouchContainerMeta(t *testing.T) {
 				"/home/admin/logs": struct{}{},
 			},
 		},
-		Created: "2018-12-18T21:36:18.054277464+08:00",
+		Created: "2018-12-18T13:36:18.054277464Z",
 		Driver:  "overlay2",
 		ExecIds: "",
 		Snapshotter: &pouchtypes.SnapshotterData{
@@ -417,3 +417,26 @@ func TestToPouchContainerMeta(t *testing.T) {
 }
 
 func int64Ptr(i int) *int64 { u := int64(i); return &u }
+
+func TestConvertTime(t *testing.T) {
+	tests := []struct {
+		srcTime string
+		expect  string
+	}{
+		{
+			srcTime: "2019-02-19T14:51:10.853959248+08:00",
+			expect:  "2019-02-19T06:51:10.853959248Z",
+		},
+		{
+			srcTime: "2019-02-19T13:51:10.853959248Z",
+			expect:  "2019-02-19T13:51:10.853959248Z",
+		},
+	}
+
+	for _, tt := range tests {
+		result := convertTime(tt.srcTime)
+		if result != tt.expect {
+			t.Errorf("failed to convert docker time to pouch time, expect %s, but %s", tt.expect, result)
+		}
+	}
+}


### PR DESCRIPTION
In docker environment, we get container info by api "containers/{cid}/json", and some fields such as Created, StartedAt and FinishedAt are parsed as Local layout. For example: "2019-02-19T14:51:10.853959248+08:00" 
But in pouch environment, the fields including Created, StartedAt and FinishedAt are parsed as UTC layout like "2019-02-19T06:51:10.853959248Z" and stored in string format.
In d2p-migrator, we should also convert time from Local layout to UTC layout.